### PR TITLE
Avoid error in PHP 8.5 due to undefined SCRIPT_FILENAME

### DIFF
--- a/src/CookieConsent.php
+++ b/src/CookieConsent.php
@@ -141,7 +141,7 @@ class CookieConsent
 
     private function getProcessingDirectoryConfig(): string
     {
-        $scriptPath = realpath(dirname($_SERVER['SCRIPT_FILENAME']));
+        $scriptPath = realpath(dirname($_SERVER['SCRIPT_FILENAME'] ?? '.'));
         $basePath   = realpath(base_path());
         $publicPath = realpath(public_path());
 

--- a/src/CookieConsentServiceProvider.php
+++ b/src/CookieConsentServiceProvider.php
@@ -104,7 +104,7 @@ class CookieConsentServiceProvider extends ServiceProvider
      */
     private function updateProcessingDirectoryConfig(): void
     {
-        $scriptPath = realpath(dirname($_SERVER['SCRIPT_FILENAME']));
+        $scriptPath = realpath(dirname($_SERVER['SCRIPT_FILENAME'] ?? '.'));
         $basePath   = realpath(base_path());
         $publicPath = realpath(public_path());
 


### PR DESCRIPTION
When the cookie consent package is installed and PHP 8.5 is used, all artisan command line calls fail due to PHP 8.5 reporting an error that `$_SERVER['SCRIPT_FILENAME']` doesn't exist.