### PR TITLE
Assets URLs are generated with /public/ under Laravel Octane/Swoole + Docker causing 404

### DIFF
--- a/src/CookieConsent.php
+++ b/src/CookieConsent.php
@@ -125,23 +125,7 @@ class CookieConsent
      */
     private function getDynamicAsset(string $path): string
     {
-        if (config('laravel-cookie-consent.system_processing_directory') == 'public') {
-            $position = strpos($path, 'public/');
-            $result = $path;
-            if ($position === 0) {
-                $result = preg_replace('/public/', '', $path, 1);
-            }
-        } else if (
-            (str_contains(realpath(public_path()), 'public\public') ||
-            str_contains(realpath(public_path()), 'public/public')) &&
-            PHP_OS_FAMILY === 'Windows'
-        ) {
-            $result = 'public/' . $path;
-        } else {
-            $result = in_array(request()->ip(), ['127.0.0.1']) && (config('laravel-cookie-consent.system_processing_directory') != 'root') ? $path : 'public/' . $path;
-        }
-
-        return asset($result);
+        return asset($path);
     }
 
     public static function getRemoveInvalidCharacters($str): array|string


### PR DESCRIPTION
This resolves https://github.com/devrabiul/laravel-cookie-consent/issues/8

As Marcin mentioned in the issue, this package unexpectedly adds `/public/` prefix on environment based on Docker. As I have tested on my environment, which is slightly different, it works like a charm with my edits.