### PR TITLE
Fix: Prevent QueryException during bootstrap when database cache is not ready on running GitHub Workflow test

### DIFF
--- a/src/CookieConsentServiceProvider.php
+++ b/src/CookieConsentServiceProvider.php
@@ -105,19 +105,26 @@ class CookieConsentServiceProvider extends ServiceProvider
     {
         $script = $_SERVER['SCRIPT_FILENAME'] ?? getcwd() ?? '';
         $cacheKey = 'SYSTEM_DOMAIN_POINTED_DIRECTORY_' . md5($script);
-        $systemProcessingDirectory = Cache::rememberForever($cacheKey, function () use ($script) {
-            $scriptPath = realpath(dirname($script));
-            $basePath   = realpath(base_path());
-            $publicPath = realpath(public_path());
 
-            if ($scriptPath === $publicPath) {
-                return 'public';
-            } elseif ($scriptPath === $basePath) {
-                return 'root';
-            }
-            return 'unknown';
-        });
+        try {
+            $systemProcessingDirectory = Cache::rememberForever($cacheKey, function () use ($script) {
+                $scriptPath = realpath(dirname($script));
+                $basePath   = realpath(base_path());
+                $publicPath = realpath(public_path());
+
+                if ($scriptPath === $publicPath) {
+                    return 'public';
+                } elseif ($scriptPath === $basePath) {
+                    return 'root';
+                }
+                return 'unknown';
+            });
+        } catch (\Exception $e) {
+            // Fallback for CI/migration phase where cache/database might not be ready
+            $systemProcessingDirectory = 'unknown';
+        }
 
         config(['laravel-cookie-consent.system_processing_directory' => $systemProcessingDirectory]);
     }
+
 }


### PR DESCRIPTION
### Description
This PR fixes a `QueryException` that occurs during the Laravel bootstrap process (e.g., during `artisan package:discover` on **CI/CD** runs). 

The issue happens when the application is configured to use the `database` cache driver, but the `cache` table hasn't been created yet (fresh install/migration phase). Since [CookieConsentServiceProvider](cci:2:./vendor/devrabiul/laravel-cookie-consent/src/CookieConsentServiceProvider.php:8:0-129:1) calls `Cache::rememberForever` inside its [boot](cci:1://file:./vendor/devrabiul/laravel-cookie-consent/src/CookieConsentServiceProvider.php:10:4-28:5) method, it triggers a database connection before the system is ready.

### Changes
Wrapped the `Cache::rememberForever` call in a `try-catch` block in [CookieConsentServiceProvider](cci:2://file:./vendor/devrabiul/laravel-cookie-consent/src/CookieConsentServiceProvider.php:8:0-129:1). If the cache driver is unavailable, it gracefully falls back to a default value without crashing the entire application.

Relates to issue #11 
