### PR TITLE
Register AssetsServiceProvider conditionally

### DIFF
--- a/src/CookieConsentServiceProvider.php
+++ b/src/CookieConsentServiceProvider.php
@@ -20,7 +20,10 @@ class CookieConsentServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->updateProcessingDirectoryConfig();
-        $this->app->register(AssetsServiceProvider::class);
+
+        if (! $this->app->runningInConsole()) {
+            $this->app->register(AssetsServiceProvider::class);
+        }
 
         $this->registerResources();
         if ($this->app->runningInConsole()) {


### PR DESCRIPTION
This PR fixes problems when running artisan command on CLI because the AssetsServiceProvider must not be registered there.