### PR TITLE
fix: add defer to script.js, remove unused script-utils request

### DIFF
--- a/resources/views/cookie-consent.blade.php
+++ b/resources/views/cookie-consent.blade.php
@@ -132,11 +132,34 @@
 
 <script type="text/javascript">
     "use strict";
-    // Load analytics/tracking services based on preferences
 
-    // Then define your service loader
+    /**
+     * Fallback preferences reader used when script.js has not yet exposed
+     * window.getCookiePreferences via its own DOMContentLoaded listener.
+     *
+     * Because script.js is loaded with `defer`, both it and this inline block
+     * register DOMContentLoaded listeners before the event fires. Listener
+     * order is registration order, so this inline listener runs first and
+     * window.getCookiePreferences is not yet available. This self-contained
+     * implementation avoids that race without requiring a second HTTP request.
+     */
+    function _getConsentPreferences() {
+        const consentRoot = document.querySelector('.cookie-consent-root');
+        const prefix = consentRoot?.getAttribute('data-cookie-prefix') || 'cookie_consent';
+        const name = prefix + '_preferences=';
+        const decoded = decodeURIComponent(document.cookie);
+        for (let part of decoded.split(';')) {
+            part = part.trim();
+            if (part.indexOf(name) === 0) {
+                try { return JSON.parse(part.substring(name.length)); } catch (e) {}
+            }
+        }
+        return null;
+    }
+
+    // Load analytics/tracking services based on preferences
     window.loadCookieCategoriesEnabledServices = function () {
-        const preferences = getCookiePreferences();
+        const preferences = (typeof getCookiePreferences === 'function' ? getCookiePreferences() : null) ?? _getConsentPreferences();
         if (!preferences) return;
 
         @foreach ($cookieConfig['cookie_categories'] as $category => $details)

--- a/src/CookieConsent.php
+++ b/src/CookieConsent.php
@@ -92,29 +92,37 @@ class CookieConsent
     /**
      * Generate the HTML for the required scripts.
      *
-     * @return string The HTML link tag for the scripts.
+     * The script is loaded with the `defer` attribute so it does not block
+     * page rendering. The `/laravel-cookie-consent/script-utils` route is no
+     * longer requested because it only served an empty `window.onload` stub
+     * that had no effect, while still adding a full HTTP round-trip to the
+     * browser's critical request chain.
+     *
+     * @return string The HTML script tag for the cookie consent JS.
      */
     public function scriptsPath(): string
     {
-        $script = $this->scriptTag('vendor/devrabiul/laravel-cookie-consent/assets/js/script.js');
         $defaultJsPath = 'packages/devrabiul/laravel-cookie-consent/js/script.js';
         if (File::exists(public_path($defaultJsPath))) {
-            $script = $this->scriptTag($defaultJsPath);
+            return $this->scriptTag($defaultJsPath);
         }
 
-        $script .= '<script src="' . route('laravel-cookie-consent.script-utils') . '"></script>';
-        return $script;
+        return $this->scriptTag('vendor/devrabiul/laravel-cookie-consent/assets/js/script.js');
     }
 
     /**
-     * Generate a script tag with the given source path.
+     * Generate a deferred script tag with the given source path.
+     *
+     * Using `defer` ensures the script is fetched in parallel with HTML
+     * parsing and executed only after the document is ready, without
+     * blocking the critical rendering path.
      *
      * @param string $src
      * @return string
      */
     private function scriptTag(string $src): string
     {
-        return '<script src="' . $this->getDynamicAsset($src) . '"></script>';
+        return '<script src="' . $this->getDynamicAsset($src) . '" defer></script>';
     }
 
     /**


### PR DESCRIPTION
The cookie consent scripts were loaded synchronously, creating a critical request chain that PageSpeed Insights flagged (~792ms added latency):

1. script.js blocked rendering (no defer/async attribute)
2. script-utils was fetched as a second chained request, but its endpoint only returned an empty `window.onload` stub with no effect

Changes:
- scriptsPath() now emits a single `defer` script tag for script.js
- scriptTag() updated to include the `defer` attribute
- script-utils route call removed from scriptsPath()
- Added _getConsentPreferences() fallback in the blade view to avoid a DOMContentLoaded listener race: because script.js is deferred, both it and the inline block register DOMContentLoaded listeners before the event fires; the inline listener runs first, so window.getCookiePreferences is not yet available. The fallback reads the preferences cookie directly.